### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Include the package locally in your repository.
 
 The plugin can be installed with little-to-no configuration needed. Once installed, you can access the variables as expected within your code using `process.env`.
 
+For example: `.env`
+```
+MY_VARIABLE=something_cool
+```
+
+`console.log(process.env.MY_VARIABLE);`
+
 The example bellow shows the defaults, as well as a description of each parameter.
 
 ```javascript


### PR DESCRIPTION
I updated the README to add a simple example making it more clear how to pull the variable from the *process.env* object.