### PR TITLE
docs: expand description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,31 @@ Include the package locally in your repository.
 
 `npm install dotenv-webpack --save`
 
+### Description
+
+`dotenv-webpack` wraps `dotenv` and `Webpack.DefinePlugin`. As such, it overwrites existing anyexisting `DefinePlugin` configurations. Also, like `DefinePlugin`, it does a text replace in the resulting bundle for any instances of `process.env`. 
+
+As such, if used with `React` in production, make sure to include `NODE_ENV=production` inside your `.env` file.
+If used with Node, this is not compatible with any calls to `process.env`.
+
+Also, be aware that all information in your `.env` file will be included in the resulting bundle. Please do not share any secret information in your client bundle. Instead, make a separate `.client.env` file.
+
 ### Usage
 
-The plugin can be installed with little-to-no configuration needed. Once installed, you can access the variables as expected within your code using `process.env`.
+The plugin can be installed with little-to-no configuration needed. Once installed, you can access the variables within your code using `process.env` as you would with `dotenv`.
 
 The example bellow shows the defaults, as well as a description of each parameter.
 
+###### Create a .env file
+
+```
+// .env
+DB_HOST=127.0.0.1
+DB_PASS=foobar
+S3_API=mysecretkey
+
+```
+###### Add it to your Webpack config file
 ```javascript
 // webpack.config.js
 const Dotenv = require('dotenv-webpack');
@@ -33,13 +52,25 @@ module.exports = {
   ...
   plugins: [
     new Dotenv({
-      path: './.my.env', // if not simply .env
+      path: './.env // Path to .env file. Use a separate file for client configuration
       safe: true // lets load the .env.example file as well
     })
   ]
   ...
 };
 ```
+
+###### Use in your code
+
+```
+// bundle.js
+console.log(process.env.DB_HOST);
+// '127.0.0.1'
+```
+
+###### Recommended
+Add `.env` to your `.gitignore` file
+
 
 ### Properties
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports = {
   ...
   plugins: [
     new Dotenv({
-      path: './.env // Path to .env file. Use a separate file for client configuration
+      path: './.env' // Path to .env file. Use a separate file for client configuration
       safe: true // lets load the .env.example file as well
     })
   ]

--- a/README.md
+++ b/README.md
@@ -60,9 +60,19 @@ module.exports = {
 ###### Use in your code
 
 ```
-// bundle.js
+// file1.js
 console.log(process.env.DB_HOST);
 // '127.0.0.1'
+```
+
+###### Resulting bundle
+```
+// bundle.js
+console.log({
+	DB_HOST='127.0.0.1',
+	DB_PASS='foobar',
+	S3_API='mysecretkey'
+}.DB_HOST);
 ```
 
 ###### Recommended

--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ Include the package locally in your repository.
 
 ### Description
 
-`dotenv-webpack` wraps `dotenv` and `Webpack.DefinePlugin`. As such, it overwrites existing anyexisting `DefinePlugin` configurations. Also, like `DefinePlugin`, it does a text replace in the resulting bundle for any instances of `process.env`. 
-
-As such, if used with `React` in production, make sure to include `NODE_ENV=production` inside your `.env` file.
-If used with Node, this is not compatible with any calls to `process.env`.
+`dotenv-webpack` wraps `dotenv` and `Webpack.DefinePlugin`. As such, it overwrites existing any existing `DefinePlugin` configurations. Also, like `DefinePlugin`, it does a text replace in the resulting bundle for any instances of `process.env`.
 
 Also, be aware that all information in your `.env` file will be included in the resulting bundle. Please do not share any secret information in your client bundle. Instead, make a separate `.client.env` file.
 


### PR DESCRIPTION
@mrsteele 
Here's a PR for https://github.com/mrsteele/dotenv-webpack/issues/39

1. Suggestions from @fakiolinho on explaining `webpack.DefinePlugin` being used under the hood
2. Updated usage examples including your template
3. Suggestions for a separate client `.env` file in order to prevent secrets from leaking into the client side bundle