### PR TITLE
code example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports = {
   ...
   plugins: [
     new Dotenv({
-      path: './.env' // Path to .env file (this is the default)
+      path: './.env', // Path to .env file (this is the default)
       safe: true // load .env.example (defaults to "false" which does not use dotenv-safe)
     })
   ]


### PR DESCRIPTION
there is a typo in the code example, copy/paste is not working.