### PR TITLE
Adding silent option to suppress warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "nyc": "^10.3.2",
     "rimraf": "^2.6.1",
     "semantic-release": "^6.3.6",
+    "sinon": "^2.3.2",
     "standard": "^10.0.2",
     "validate-commit-msg": "^2.12.1",
     "webpack": "^2.5.1"

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,15 @@ class Dotenv {
    * @param {String} [options.path=./.env] - The location of the environment variable.
    * @param {Bool|String} [options.safe=false] - If false ignore safe-mode, if true load `'./.env.example'`, if a string load that file as the sample.
    * @param {Bool} [options.systemvars=false] - If true, load system environment variables.
+   * @param {Bool} [options.silent=false] - If true, suppress warnings, if false, display warnings.
    * @returns {webpack.DefinePlugin}
    */
   constructor (options) {
     options = Object.assign({
       path: './.env',
       safe: false,
-      systemvars: false
+      systemvars: false,
+      silent: false
     }, options)
 
     // Catch older packages, but hold their hand (just for a bit)
@@ -23,7 +25,9 @@ class Dotenv {
       if (options.safe) {
         options.safe = options.sample
       }
-      console.warn('dotend-webpack: "options.sample" is a deprecated property. Please update your configuration to use "options.safe" instead.')
+      if (!options.silent) {
+        console.warn('dotenv-webpack: "options.sample" is a deprecated property. Please update your configuration to use "options.safe" instead.')
+      }
     }
 
     let vars = {}
@@ -33,7 +37,7 @@ class Dotenv {
       })
     }
 
-    const env = this.loadFile(options.path)
+    const env = this.loadFile(options.path, options.silent)
 
     let blueprint = env
     if (options.safe) {
@@ -41,7 +45,7 @@ class Dotenv {
       if (options.safe !== true) {
         file = options.safe
       }
-      blueprint = this.loadFile(file)
+      blueprint = this.loadFile(file, options.silent)
     }
 
     Object.keys(blueprint).map(key => {
@@ -64,13 +68,16 @@ class Dotenv {
   /**
    * Load and parses a file.
    * @param {String} file - The file to load.
+   * @param {Bool} silent - If true, suppress warnings, if false, display warnings.
    * @returns {Object}
    */
-  loadFile (file) {
+  loadFile (file, silent) {
     try {
       return dotenv.parse(fs.readFileSync(file))
     } catch (err) {
-      console.warn(`Failed to load ${file}.`)
+      if (!silent) {
+        console.warn(`Failed to load ${file}.`)
+      }
       return {}
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,7 @@ class Dotenv {
       if (options.safe) {
         options.safe = options.sample
       }
-      if (!options.silent) {
-        console.warn('dotenv-webpack: "options.sample" is a deprecated property. Please update your configuration to use "options.safe" instead.')
-      }
+      this.warn('dotenv-webpack: "options.sample" is a deprecated property. Please update your configuration to use "options.safe" instead.', options.silent)
     }
 
     let vars = {}
@@ -75,11 +73,18 @@ class Dotenv {
     try {
       return dotenv.parse(fs.readFileSync(file))
     } catch (err) {
-      if (!silent) {
-        console.warn(`Failed to load ${file}.`)
-      }
+      this.warn(`Failed to load ${file}.`, silent)
       return {}
     }
+  }
+
+  /**
+   * Displays a console message if 'silent' is falsey
+   * @param {String} msg - The message.
+   * @param {Bool} silent - If true, display the message, if false, suppress the message.
+   */
+  warn (msg, silent) {
+    !silent && console.warn(msg)
   }
 }
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -3,6 +3,7 @@
 // Tests suite
 import path from 'path'
 import chai from 'chai'
+import sinon from 'sinon'
 
 // The star of the show
 import Src from '../src'
@@ -19,6 +20,8 @@ const envDefJson = {'process.env.TEST': '"hi"'}
 const envEmptyJson = {}
 const envSimpleJson = {'process.env.TEST': '"testing"'}
 const envMissingOneJson = {'process.env.TEST': '""', 'process.env.TEST2': '"Hello"'}
+
+const consoleSpy = sinon.spy(console, 'warn')
 
 function runTests (Obj, name) {
   function envTest (config) {
@@ -106,6 +109,18 @@ function runTests (Obj, name) {
         envTest({path: envSimple, safe: true, sample: envSimpleExample}).should.deep.equal(envSimpleJson)
       })
 
+      it('Should display deprecation warning by default', () => {
+        consoleSpy.reset()
+        envTest({path: envSimple, safe: true, sample: envSimpleExample}).should.deep.equal(envSimpleJson)
+        consoleSpy.calledOnce.should.equal(true)
+      })
+
+      it('Should not display deprecation warning when silent mode enabled', () => {
+        consoleSpy.reset()
+        envTest({path: envSimple, safe: true, sample: envSimpleExample, silent: true}).should.deep.equal(envSimpleJson)
+        consoleSpy.called.should.equal(false)
+      })
+
       it('Should fail naturally when using deprecated values', () => {
         function errorTest () {
           envTest({path: envMissingOne, safe: true, sample: envMissingOneExample})
@@ -116,6 +131,20 @@ function runTests (Obj, name) {
 
       it('Should not fail naturally when using deprecated values improperly', () => {
         envTest({path: envMissingOne, sample: envMissingOneExample}).should.deep.equal(envMissingOneJson)
+      })
+    })
+
+    describe('Silent mode', () => {
+      it('Should display warning by default', () => {
+        consoleSpy.reset()
+        envTest({path: false})
+        consoleSpy.calledOnce.should.equal(true)
+      })
+
+      it('Should not display warning when silent mode enabled', () => {
+        consoleSpy.reset()
+        envTest({path: false, silent: true})
+        consoleSpy.called.should.equal(false)
       })
     })
   })


### PR DESCRIPTION
I'm using this in a site generator and the project being built may or may not have a .env file. Since that file is optional I don't want to display the warning about not being able to load the .env file.

I also suppressed the deprecation warning for consistency although I'm not sure it's a good idea in that case. I did not suppress the exception when a value is missing from the .env file since that's an error and not a warning.