### PR TITLE
fix: Load process.env and merge with .env vars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ class Dotenv {
       }
       blueprint = this.loadFile(file, options.silent)
     }
+    
+    blueprint = Object.assign(blueprint, process.env)
 
     Object.keys(blueprint).map(key => {
       const value = (env[key] || env[key] === '') ? env[key] : vars[key]


### PR DESCRIPTION
## Issue

This Plugin modifies environment variables that have already been set by the system.
This contradicts my basic understanding of  [https://www.npmjs.com/package/dotenv](https://www.npmjs.com/package/dotenv)

> ## What happens to environment variables that were already set?
> We will never modify any environment variables that have already been set. In particular, if there is a variable in your .env file which collides with one that already exists in your environment, then that variable will be skipped. This behavior allows you to override all .env configurations with a machine-specific environment, although it is not recommended.

**Source:** [https://www.npmjs.com/package/dotenv#what-happens-to-environment-variables-that-were-already-set](https://www.npmjs.com/package/dotenv#what-happens-to-environment-variables-that-were-already-set)

## Example

**.env**

```.env
TEST_VAR=SHOULD_NOT_OVERWRITE
```

**webpack.js**

```js
...
new Dotenv({ systemvars: true })
...
```

**bash**

```bash
TEST_VAR=THIS_VAL_IS_RIGHT webpack ...
```

## TODO

- [ ] Fix tests