### PR TITLE
fix: Provide single-quoted booleans to webpack.DefinePlugin.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,14 @@ class Dotenv {
     })
 
     const formatData = Object.keys(vars).reduce((obj, key) => {
-      obj[`process.env.${key}`] = JSON.stringify(vars[key])
+      let value = vars[key]
+      // Do not double-stringify booleans
+      if (value === 'true') {
+        value = true
+      } else if (value === 'false') {
+        value = false
+      }
+      obj[`process.env.${key}`] = JSON.stringify(value)
       return obj
     }, {})
 

--- a/test/envs/.withbool
+++ b/test/envs/.withbool
@@ -1,0 +1,2 @@
+FALSEY_VALUE=false
+TRUTHY_VALUE=true

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -17,11 +17,13 @@ const envMissingOne = path.resolve(__dirname, './envs/.missingone')
 const envMissingOneExample = path.resolve(__dirname, './envs/.missingone.example')
 const envSystemvars = path.resolve(__dirname, './envs/.systemvars')
 const envSystemvarsExample = path.resolve(__dirname, './envs/.systemvars.example')
+const envWithBool = path.resolve(__dirname, './envs/.withbool')
 
 const envDefJson = {'process.env.TEST': '"hi"'}
 const envEmptyJson = {}
 const envSimpleJson = {'process.env.TEST': '"testing"'}
 const envMissingOneJson = {'process.env.TEST': '""', 'process.env.TEST2': '"Hello"'}
+const envWithBoolJson = {'process.env.FALSEY_VALUE': 'false', 'process.env.TRUTHY_VALUE': 'true'}
 
 const consoleSpy = sinon.spy(console, 'warn')
 
@@ -159,6 +161,12 @@ function runTests (Obj, name) {
         consoleSpy.reset()
         envTest({path: false, silent: true})
         consoleSpy.called.should.equal(false)
+      })
+    })
+
+    describe('With a boolean value', () => {
+      it('Should set booleans to be a single-quoted string.', () => {
+        envTest({path: envWithBool}).should.deep.equal(envWithBoolJson)
       })
     })
   })


### PR DESCRIPTION
Boolean values must be provided to webpack's DefinePlugin  as single-quoted strings (e.g. `process.env.FALSEY_VALUE = 'false'`) instead of double-quoted strings (e.g. `process.env.FALSEY_VALUE = "'false'"` or `process.env.FALSEY_VALUE = JSON.stringify('false')`). This is because webpack evaluates double-quoted booleans as strings instead of booleans, resulting in unexpected behavior where `process.env.FALSEY_VALUE` gets evaluated as the string `"false"`, which is truthy.

The solution to this is to provide single-quoted booleans when creating a new `DefinePlugin` so that they can be evaluated correctly.