### PR TITLE
Add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for dotenv-webpack
+// Project: https://github.com/mrsteele/dotenv-webpack
+// Definitions by: Karol Majewski <https://github.com/karol-majewski>
+// TypeScript Version: 2.7.2
+
+import * as webpack from 'webpack';
+
+declare class DotenvWebpackPlugin extends webpack.Plugin {
+  constructor(options?: DotenvWebpackPlugin.Options);
+}
+
+declare namespace DotenvWebpackPlugin {
+  interface Options {
+    /**
+     * The path to your environment variables. Default: `'./.env'`.
+     */
+    path?: string;
+
+    /**
+     * If `false` ignore safe-mode, if `true` load `'./.env.example'`, if a `string` load that file as the sample. Default: `false`.
+     */
+    safe?: boolean;
+
+    /**
+     * Set to `true` if you would rather load all system variables as well (useful for CI purposes). Default: `false`.
+     */
+    systemvars?: boolean;
+
+    /**
+     * If `true`, all warnings will be surpressed. Default: `false`.
+     */
+    silent?: boolean;
+  }
+}
+
+export = DotenvWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A simple webpack plugin to support dotenv.",
   "version": "0.0.0-semantically-released",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "precommit": "npm run lint",
     "prepush": "npm t",
@@ -42,6 +43,7 @@
     "webpack": "^1 || ^2 || ^3 || ^4"
   },
   "dependencies": {
+    "@types/webpack": "^4.1.2",
     "dotenv": "^5.0.1"
   },
   "devDependencies": {
@@ -61,7 +63,8 @@
     "webpack": "^3.10.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "standard": {
     "parser": "babel-eslint"


### PR DESCRIPTION
Solves #99.

- Used [module class template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html) from TypeScript documentation
- Included `@types/webpack` so the library consumers won't have to install them manually as a peer dependency (as recommended [here](https://github.com/Microsoft/types-publisher/issues/81#issuecomment-234051338))
- I took the liberty of using the comments from `README.md` – I hope that's okay?