### PR TITLE
webpack should be direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "webpack": "^1 || ^2 || ^3 || ^4"
   },
   "dependencies": {
-    "dotenv": "^5.0.1"
+    "dotenv": "^5.0.1",
+    "webpack": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -58,8 +59,7 @@
     "nyc": "^12.0.1",
     "rimraf": "^2.6.2",
     "sinon": "^6.0.0",
-    "standard": "^11.0.0",
-    "webpack": "^4.6.0"
+    "standard": "^11.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
lerna couldn't resolve webpack dependency.

We've lerna.js setup.
- A project use webpack@4.
- Another project use webpack@3
When we run dotenv-webpack from webpack@3 project's scope, it always resolves to webpack@4 as webpack@4 is on the global scope.