### PR TITLE
chore: update documentation about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A secure webpack plugin that supports dotenv and other environment variables and
 
 Include the package locally in your repository.
 
-`npm install dotenv-webpack --save`
+`npm install dotenv-webpack --save-dev`
 
 ### Description
 


### PR DESCRIPTION
Modified documentation to use `--save-dev` flag to install plugin
as a dev-dependency. This makes it more aligned with what
other plugins do in their documentation.