### PR TITLE
chore(package): update babel to version ^7.5.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ try {
   plugin = require('./dist').default
 } catch (err) {
   if (err.code === 'MODULE_NOT_FOUND') {
-    require('babel-register')
+    require('@babel/register')
     plugin = require('./src').default
   } else {
     console.log(err)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "predoc": "rimraf docs",
     "doc": "esdoc -c config/doc.json",
     "pretest": "npm run build",
-    "test": "nyc _mocha --require babel-core/register",
+    "test": "nyc _mocha --require @babel/register",
     "posttest": "nyc report --reporter=lcov",
     "prebuild": "rimraf dist",
     "build": "babel --copy-files --out-dir dist src",
@@ -45,11 +45,12 @@
     "dotenv-defaults": "^1.0.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-eslint": "^10.0.1",
-    "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-register": "^6.26.0",
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
+    "@babel/preset-env": "^7.5.5",
+    "@babel/register": "^7.5.5",
+    "babel-eslint": "^10.0.2",
     "chai": "^4.1.2",
     "esdoc": "^1.0.4",
     "esdoc-standard-plugin": "^1.0.0",
@@ -70,10 +71,10 @@
   "browser": "browser.js",
   "babel": {
     "presets": [
-      "env"
+      "@babel/preset-env"
     ],
     "plugins": [
-      "transform-object-assign"
+      "@babel/plugin-transform-object-assign"
     ]
   },
   "nyc": {


### PR DESCRIPTION
### Description
Update from Babel v6 to Babel v7

**Following package updates**
- @babel/cli@^7.5.5
- @babel/core@^7.5.5
- @babel/plugin-transform-object-assign@^7.2.0
- @babel/preset-env@^7.5.5
- @babel/register@^7.5.5
- @babel-eslint@^10.0.2

** index.js **
- Uses the v7 version `@babel/register` rather than the v6 `babel-register`

The rationale is that most new projects start with Babel 7 and there are potential conflicts with babel versions.