### PR TITLE
chore: clarify behaviour of safe option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Add `.env` to your `.gitignore` file
 Use the following properties to configure your instance.
 
 * **path** (`'./.env'`) - The path to your environment variables.
-* **safe** (`false`) - If false ignore safe-mode, if true load `'./.env.example'`, if a string load that file as the sample.
+* **safe** (`false`) - If true, load '.env.example' to verify the '.env' variables are all set. Can also be a string to a different file.
 * **systemvars** (`false`) - Set to true if you would rather load all system variables as well (useful for CI purposes).
 * **silent** (`false`) - If true, all warnings will be suppressed.
 * **expand** (`false`) - Allows your variables to be "expanded" for reusability within your `.env` file.


### PR DESCRIPTION
I think people can be misled into thinking that `safe` would just load `.env.example` as a fallback.  I know it's explained in the example further down but that can be easily missed by sorts like me :)