### PR TITLE
docs: fix readme image height attribute typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A secure webpack plugin that supports dotenv and other environment variables and
   </a>
 
   <h1>
-    <img width="30" heigth="30" src="https://raw.githubusercontent.com/motdotla/dotenv/master/dotenv.png" alt="dotenv" />
-    <img width="30" heigth="30" src="https://webpack.js.org/assets/icon-square-big.svg" alt="webpack">
+    <img width="30" height="30" src="https://raw.githubusercontent.com/motdotla/dotenv/master/dotenv.png" alt="dotenv" />
+    <img width="30" height="30" src="https://webpack.js.org/assets/icon-square-big.svg" alt="webpack">
     dotenv-webpack
   </h1>
 </div>


### PR DESCRIPTION
Fixing image height attribute typos.

Also, a separate issue, but I notice that the HTML doesn't render properly on npm like it does on GitHub:

https://www.npmjs.com/package/dotenv-webpack

![Screen Shot 2020-07-15 at 7 29 47 AM](https://user-images.githubusercontent.com/615381/87545068-0a042480-c66d-11ea-909e-dc48e69a03ca.png)
