### PR TITLE
fix: webpack 5 compatibility using nested 'process.env' keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,6 @@ class Dotenv {
     const { expand } = this.config
     const formatted = Object.keys(vars).reduce((obj, key) => {
       const v = vars[key]
-      const vKey = `process.env.${key}`
       let vValue
       if (expand) {
         if (v.substring(0, 2) === '\\$') {
@@ -135,12 +134,14 @@ class Dotenv {
         vValue = v
       }
 
-      obj[vKey] = JSON.stringify(vValue)
+      obj[key] = JSON.stringify(vValue)
 
       return obj
     }, {})
 
-    return formatted
+    return {
+      'process.env': formatted
+    }
   }
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,9 +22,9 @@ const envDefaults = path.resolve(__dirname, './envs/.defaults')
 
 const buildExpectation = (obj) => {
   const raw = Object.keys(obj).reduce((all, key) => {
-    all[`process.env.${key}`] = JSON.stringify(obj[key])
+    all['process.env'][key] = JSON.stringify(obj[key])
     return all
-  }, {})
+  }, { 'process.env': {} })
 
   return raw
 }
@@ -199,15 +199,16 @@ function runTests (Obj, name) {
 
     describe('System variables', () => {
       test('Should allow system env variables', () => {
-        const test = envTest({ path: envSimple, systemvars: true })
-        const key = Object.keys(envSimpleJson)[0]
-        const value = envSimpleJson[key]
+        const test = envTest({ path: envSimple, systemvars: true })['process.env']
+        const env = envSimpleJson['process.env']
+        const key = Object.keys(env)[0]
+        const value = env[key]
         expect(test[key]).toEqual(value)
-        expect(Object.keys(test).length > Object.keys(envSimpleJson).length).toEqual(true)
+        expect(Object.keys(test).length > Object.keys(env).length).toEqual(true)
       })
 
       test('should pass if the systemvar satisfies the requirement', () => {
-        const PATH = envTest({ safe: envSystemvarsExample, systemvars: true })['process.env.PATH']
+        const PATH = envTest({ safe: envSystemvarsExample, systemvars: true })['process.env'].PATH
         expect(typeof PATH).toEqual('string')
         expect(PATH.indexOf('/') !== -1).toEqual(true)
       })


### PR DESCRIPTION
Webpack 5 no longer polyfills `process`. #254 

Changed the `DefinePlugin` global constants from:

```js
{
    'process.env.KEY': 'VALUE'
}
```

to

```js
{
    'process.env': {
        KEY: 'VALUE'
    }
}
```

Docs on `DefinPlugin` here: https://webpack.js.org/plugins/define-plugin/