### PR TITLE
feat: compatible with rspack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,9 @@ class Dotenv {
       target,
       version
     })
+    const DefinePlugin = (compiler.webpack && compiler.webpack.DefinePlugin) || require('webpack').DefinePlugin
 
-    new compiler.webpack.DefinePlugin(data).apply(compiler)
+    new DefinePlugin(data).apply(compiler)
   }
 
   gatherVariables () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv-defaults'
 import fs from 'fs'
-import { DefinePlugin } from 'webpack'
 
 // Mostly taken from here: https://github.com/motdotla/dotenv-expand/blob/master/lib/main.js#L4
 const interpolate = (env, vars) => {
@@ -47,7 +46,7 @@ class Dotenv {
       version
     })
 
-    new DefinePlugin(data).apply(compiler)
+    new compiler.webpack.DefinePlugin(data).apply(compiler)
   }
 
   gatherVariables () {


### PR DESCRIPTION
Use `compiler.webpack.DefinePlugin` instead of require from webpack, this is also available way in webpack, and can be compatible with rspack.

This can also avoid requiring wrong webpack when using monorepo and have multiple webpack in node_modules