### PR TITLE
feat: specified systemvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Use the following properties to configure your instance.
 * **path** (`'./.env'`) - The path to your environment variables. This same path applies to the `.env.example` and `.env.defaults` files. [Read more here](#about-path-settings).
 * **safe** (`false`) - If true, load '.env.example' to verify the '.env' variables are all set. Can also be a string to a different file.
 * **allowEmptyValues** (`false`) - Whether to allow empty strings in safe mode. If false, will throw an error if any env variables are empty (but only if safe mode is enabled).
-* **systemvars** (`false`) - Set to true if you would rather load all system variables as well (useful for CI purposes).
+* **systemvars** (`false`) - Set to true if you would rather load all system variables as well. Set to an array of strings to load only specified system variables. (useful for CI purposes).
 * **silent** (`false`) - If true, all warnings will be suppressed.
 * **expand** (`false`) - Allows your variables to be "expanded" for reusability within your `.env` file.
 * **defaults** (`false`) - Adds support for `dotenv-defaults`. If set to `true`, uses `./.env.defaults`. If a string, uses that location for a defaults file. Read more at [npm](https://www.npmjs.com/package/dotenv-defaults).

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class Dotenv {
    * @param {Object} options - The parameters.
    * @param {String} [options.path=./.env] - The location of the environment variable.
    * @param {Boolean|String} [options.safe=false] - If false ignore safe-mode, if true load `'./.env.example'`, if a string load that file as the sample.
-   * @param {Boolean} [options.systemvars=false] - If true, load system environment variables.
+   * @param {Boolean|String[]} [options.systemvars=false] - If true, load all system environment variables, if an array of strings load only specified system environment variables
    * @param {Boolean} [options.silent=false] - If true, suppress warnings, if false, display warnings.
    * @param {String} [options.prefix=process.env.] - The prefix, used to denote environment variables.
    * @returns {webpack.DefinePlugin}
@@ -82,7 +82,15 @@ class Dotenv {
   }
 
   initializeVars () {
-    return (this.config.systemvars) ? Object.assign({}, process.env) : {}
+    const initialVars = {}
+    if (Array.isArray(this.config.systemvars)) {
+      this.config.systemvars.forEach((key) => {
+        initialVars[key] = process.env[key]
+      })
+    } else if (this.config.systemvars) {
+      Object.assign(initialVars, process.env)
+    }
+    return initialVars
   }
 
   getEnvs () {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -7,6 +7,7 @@ const TEST2 = process.env.TEST2
 
 // System
 const PATH = process.env.PATH
+const SECRET = process.env.SECRET
 
 // Expanded
 const NODE_ENV = process.env.NODE_ENV

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -267,11 +267,14 @@ describe.each(versions)('%s', (_, DotenvPlugin) => {
 
   describe('System variables', () => {
     const originalPath = process.env.PATH
+    const originalSecret = process.env.SECRET
     beforeEach(() => {
       process.env.PATH = '/usr/local/bin:/usr/local/sbin:'
+      process.env.SECRET = '_secret_value_'
     })
     afterEach(() => {
       process.env.PATH = originalPath
+      process.env.SECRET = originalSecret
     })
 
     test('Should allow system env variables', (done) => {
@@ -283,7 +286,21 @@ describe.each(versions)('%s', (_, DotenvPlugin) => {
       compile(config, (result) => {
         expect(result).toMatch('const TEST = "testing"')
         expect(result).toMatch('const PATH = "/usr/local/bin:/usr/local/sbin:')
+        expect(result).toMatch('const SECRET = "_secret_value_')
+        done()
+      })
+    })
 
+    test('Should allow specified system env variables', (done) => {
+      const config = getConfig(
+        'web',
+        new DotenvPlugin({ path: envSimple, systemvars: ['PATH'] })
+      )
+
+      compile(config, (result) => {
+        expect(result).toMatch('const TEST = "testing"')
+        expect(result).toMatch('const PATH = "/usr/local/bin:/usr/local/sbin:')
+        expect(result).not.toMatch('const SECRET = "_secret_value_')
         done()
       })
     })


### PR DESCRIPTION
For CI purposes, I would like to expose some environment variables as defaults to webpack without exposing _all_ environment variables.